### PR TITLE
Fix deployment when using custom secret

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
-version: 0.2.9
+version: 0.2.10
 appVersion: 2.1.0
 home: https://github.com/buzzfeed/sso
 sources:

--- a/templates/auth-deployment.yaml
+++ b/templates/auth-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         component: {{ $name }}-auth
         release: {{ .Release.Name }}
     spec:
-    {{- if .Values.provider.google.secret.serviceAccount }}
+    {{- if .Values.provider.google }}
       volumes:
         - name: google-service-account
           secret:


### PR DESCRIPTION
Fixes deployment where the custom secret is used and the service account is not provided.

```
Error: UPGRADE FAILED: template: buzzfeed-sso/templates/auth-deployment.yaml:37:18: executing "buzzfeed-sso/templates/auth-deployment.yaml" at <.Values.provider.google.secret.serviceAccount>: nil pointer evaluating interface {}.serviceAccount
```