### PR TITLE
Use API version networking.k8s.io/v1 if available

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Single sign-on for your Kubernetes services using Google OAuth
 name: buzzfeed-sso
-version: 0.2.11
+version: 0.2.12
 appVersion: 2.1.0
 home: https://github.com/buzzfeed/sso
 sources:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -46,7 +46,9 @@ Return the apiVersion of deployment.
 Return the apiVersion of ingress.
 */}}
 {{- define "ingress.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
+    {{- print "networking.k8s.io/v1" -}}
+{{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
     {{- print "networking.k8s.io/v1beta1" -}}
 {{- else -}}
     {{- print "extensions/v1beta1" -}}


### PR DESCRIPTION
To support k8s 1.22+ since the old version is deprecated and will be removed https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingressclass-v122