### PR TITLE
Use API version networking.k8s.io/v1 if available

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -46,9 +46,11 @@ Return the apiVersion of deployment.
 Return the apiVersion of ingress.
 */}}
 {{- define "ingress.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.Version -}}
+    {{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
     {{- print "networking.k8s.io/v1beta1" -}}
 {{- else -}}
-    {{- print "extensions/v1beta1" -}}
+    {{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 {{- end -}}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,7 +2,8 @@
 {{- if ne .Values.auth.domain "<your_auth_domain>" -}}
 {{- $fullName := include "buzzfeed-sso.fullname" . -}}
 {{- $authDomain := .Values.auth.domain -}}
-apiVersion: {{ template "ingress.apiVersion" . }}
+{{- $apiVersion := include "ingress.apiVersion" . -}}
+apiVersion: {{ $apiVersion }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -45,19 +46,37 @@ spec:
           - path: {{ .path }}
             {{- if $pathType }}
             pathType: {{ $pathType }}
+            {{- else if eq $apiVersion "networking.k8s.io/v1" }}
+            pathType: ImplementationSpecific
             {{- end }}
             backend:
+              {{- if eq $apiVersion "networking.k8s.io/v1" }}
+              service:
+                name: {{ $fullName }}-proxy
+                port:
+                  name: http
+              {{- else }}
               serviceName: {{ $fullName }}-proxy
               servicePort: http
+              {{- end }}
           {{- end }}
           {{- range .paths }}
           - path: {{ . }}
             {{- if $pathType }}
             pathType: {{ $pathType }}
+            {{- else if eq $apiVersion "networking.k8s.io/v1" }}
+            pathType: ImplementationSpecific
             {{- end }}
             backend:
+              {{- if eq $apiVersion "networking.k8s.io/v1" }}
+              service:
+                name: {{ $fullName }}-proxy
+                port:
+                  name: http
+              {{- else }}
               serviceName: {{ $fullName }}-proxy
               servicePort: http
+              {{- end }}
           {{- end }}
   {{- end }}
   {{- if and .Values.auth.enabled .Values.auth.ingressEnabled }}
@@ -66,9 +85,19 @@ spec:
       http:
         paths:
           - path: {{ .Values.auth.ingressPath }}
+            {{- if eq $apiVersion "networking.k8s.io/v1" }}
+            pathType: ImplementationSpecific
+            {{- end }}
             backend:
+              {{- if eq $apiVersion "networking.k8s.io/v1" }}
+              service:
+                name: {{ $fullName }}-auth
+                port:
+                  name: http
+              {{- else }}
               serviceName: {{ $fullName }}-auth
               servicePort: http
+              {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
To support k8s 1.22+ since the old version is deprecated and will be removed https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingressclass-v122

I generated the manifests with `helm template . --set auth.domain=auth.example.com --kube-version 1.19` and `helm template . --set auth.domain=auth.example.com --kube-version 1.15`, then checked them against https://kube-score.com/.